### PR TITLE
Fix: correct month display issue caused by getMonth() offset

### DIFF
--- a/src/assets/configs/submitLinks/index.ts
+++ b/src/assets/configs/submitLinks/index.ts
@@ -7,12 +7,12 @@ const ENV = import.meta.env as ImportMetaEnv;
 export const SUBMIT_LINKS: SubmitLinkType = {
   "------ 트랙 선택 ------": "",
   "초격차 캠프 프론트엔드 코스":
-    ENV.VITE_APP_TEACHING_TEAM_DEFAULT_SUBMIT_LINK ?? "",
+    ENV.REACT_APP_TEACHING_TEAM_DEFAULT_SUBMIT_LINK ?? "",
   "초격차 캠프 백엔드 코스":
-    ENV.VITE_APP_TEACHING_TEAM_DEFAULT_SUBMIT_LINK ?? "",
-  "1인 창업가 개발부트캠프": ENV.VITE_APP_TEACHING_5TEAM_SUBMIT_LINK ?? "",
+    ENV.REACT_APP_TEACHING_TEAM_DEFAULT_SUBMIT_LINK ?? "",
+  "1인 창업가 개발부트캠프": ENV.REACT_APP_TEACHING_5TEAM_SUBMIT_LINK ?? "",
   "AI를 활용한 차세대 스마트 게임 개발자 양성과정":
-    ENV.VITE_APP_GAME_DEVELOPER_SUBMIT_LINK ?? "",
+    ENV.REACT_APP_GAME_DEVELOPER_SUBMIT_LINK ?? "",
   "헬스케어 데이터 기반 인공지능 디지털 의료 웹 서비스 개발자 양성과정":
-    ENV.VITE_APP_AH_TRACK_SUBMIT_LINK ?? "",
+    ENV.REACT_APP_AH_TRACK_SUBMIT_LINK ?? "",
 };

--- a/src/components/Forms/Form.Vacation.tsx
+++ b/src/components/Forms/Form.Vacation.tsx
@@ -70,10 +70,10 @@ export const FormVacation = ({
       <p className="text-2xl font-semibold pb-2 text-green-600">{`${
         new Date(duringFrom).getFullYear() || "0000"
       }.${changeTwoDay(
-        new Date(duringFrom).getMonth() || -1 + 1
+        new Date(duringFrom).getMonth() + 1 || -1 + 1
       )}.${changeTwoDay(new Date(duringFrom).getDate() || 0)} ~ ${
         new Date(duringTo).getFullYear() || "0000"
-      }.${changeTwoDay(new Date(duringTo).getMonth() || -1 + 1) || "00"}.${
+      }.${changeTwoDay(new Date(duringTo).getMonth() + 1 || -1 + 1) || "00"}.${
         changeTwoDay(new Date(duringTo).getDate() || 0) || "00"
       }(${
         Math.floor(


### PR DESCRIPTION
- Fixed an issue where the displayed month was off by one when selecting vacation dates.
- This was caused by using Date.getMonth() without properly handling its zero-based index.